### PR TITLE
Include functionality to detect state location on map

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,30 @@
+/** available states */
+const states = ["edo", "oyo", ];
+
+
+// defining the posible drop point on the screen will help to define
+// accuracy of the dropped object...
+
+// The location of each state on the screen covers a certain point,
+// defining the point of each state on the screen will help to tell the
+// accuracy of the dropped object
+
+const posibleDropZone = {
+
+  /** edo state */
+  edo: {
+    xCoord : [ 143, 181, 214 ],
+    yCoord : [ 375, 427]
+  },
+
+  oyo: {
+    xCoord : [ 81, 36, 95 ],
+    yCoord : [ 288, 359, 370 ],
+  }, 
+
+}
+
+
 // create an interactable target :: which is basically an object that
 // can respond to drag, resize etc.
 const slider = interact(".slider");
@@ -24,3 +51,67 @@ slider.draggable({
     }
   }
 });
+
+
+
+
+const check_state_drop_zone = (event) => {
+  let draggedState;     // object to represent state dragged
+  let draggedStateYpos; // represent current y position of dragged state
+  let draggedSteteXpos; // represent current x position of dragged state
+
+  // transverse through the list of states and get the state that
+  // matches the dropped object
+  states.map((state) => {
+    if (state === event.dragEvent.currentTarget.innerText){
+      draggedState = event.dragEvent.currentTarget;
+      draggedStateXpos = event.dragEvent.client.x;
+      draggedStateYpos = event.dragEvent.client.y;
+    }
+  });
+
+  console.log(
+    draggedState.innerText, 
+    "\nX --> ", draggedStateXpos,
+    "\nY --> ", draggedStateYpos
+  );
+
+  // retrieve the possible values of the xCoordinate of the dragged state
+  let possibleXcoord = Object.values(
+    posibleDropZone[draggedState.innerText].xCoord);
+
+  // retrieve the possible values of the yCoordinate of the dragged state
+  let possibleYcoord = Object.values(
+    posibleDropZone[draggedState.innerText].yCoord);
+
+  // get the min and max x position
+  stateMinXcoord = Math.min(...possibleXcoord)
+  stateMaxXcoord = Math.max(...possibleXcoord)
+
+  // get the min and max y position 
+  stateMaxYcoord = Math.max(...possibleYcoord)
+  stateMinYcoord = Math.min(...possibleYcoord)
+
+  // check if the dragged object x and y position is greater than
+  // the min but lesser the max of both the x and y coordinate of the 
+  // state representation on the map
+  if (draggedStateXpos >= stateMinXcoord 
+      && draggedStateXpos <= stateMaxXcoord) {
+
+    if(draggedStateYpos >= stateMinYcoord 
+      && draggedStateYpos <= stateMaxYcoord) {
+
+      console.log("true");
+      // increase point scored for the player for getting the 
+      // location of state on the map
+
+    }
+
+  }
+}
+
+
+
+interact('.drop-location').dropzone({
+  ondrop: check_state_drop_zone
+})

--- a/index.html
+++ b/index.html
@@ -9,11 +9,10 @@
     <script src="https://unpkg.com/interactjs/dist/interact.min.js"></script>
 </head>
 <body>
-  <h1>Starting the game</h1> 
 	<p class="slider slider-edo">edo</p>
 
 	<div class="map-container">
-	  <img src="nigeria-map.jpg" alt="Map of Nigeria" />
+	  <img class="drop-location" src="nigeria-map.jpg" alt="Map of Nigeria" />
 	</div>
 
 
@@ -24,7 +23,6 @@
 		*
 		*
 	-->
-	
-<script src='app.js'></script>
+	<script src='app.js'></script>
 </body>
 </html>


### PR DESCRIPTION
Each of the states have their outlines drawn out as path/lines on the map. The logic of this functionality is to detect the lowest and highest possible horizontal coordinates of a state's path drawn on map, same rules applies for detecting the lowest and highest possible vertical coordinate. 

When the possible coordinates are gotten, it is compared with the horizontal and vertical position of the dragged object -- which is the dragged state in this scenario. 

When and only when the dragged state's horizontal and vertical position is greater than the minimum possible coordinates  (vertical and horizontal) but lesser than the maximum possible coordinates (vertical and horizontal), then the state is said to be rightly dropped on the drop-zone.